### PR TITLE
minor fixes

### DIFF
--- a/PICADOR-Jr-Project/Include/Vector3.h
+++ b/PICADOR-Jr-Project/Include/Vector3.h
@@ -31,6 +31,9 @@ struct Vector3
 	Vector3 operator*(const Vector3& rhs) const;
 	Vector3 operator/(const Vector3& rhs) const;
 
+	bool operator==(const Vector3& rhs) const;
+	bool operator!=(const Vector3& rhs) const;
+
 	// Scalar multiplication
 	double dotProduct(const Vector3& rhs) const;
 

--- a/PICADOR-Jr-Project/Include/Vector3.h
+++ b/PICADOR-Jr-Project/Include/Vector3.h
@@ -6,7 +6,7 @@ struct Vector3
 	double x, y, z;
 
 	// Default constructor
-	Vector3(double x_, double y_, double z_): x(x_), y(y_), z(z_) {}
+	Vector3(double x_, double y_, double z_ = 0): x(x_), y(y_), z(z_) {}
 	Vector3(double xyz = 0.0): x(xyz), y(xyz), z(xyz) {}
 
 	// Data getters

--- a/PICADOR-Jr-Project/Source/FieldGrid.cpp
+++ b/PICADOR-Jr-Project/Source/FieldGrid.cpp
@@ -4,14 +4,6 @@ FieldGrid::FieldGrid(size_t resolutionX_, size_t resolutionY_, double deltaX_, d
 	Grid(resolutionX_, resolutionY_, deltaX_, deltaY_, origin_, padding_)
 {
 	this->nodeArray = std::vector<FieldData>((this->resolutionX + 2*this->padding) * (this->resolutionY+2*this->padding), FieldData());
-	for (int i = 0; i < resolutionX; i++) 
-	{
-		for (int j = 0; j < resolutionY; j++)
-		{
-			this->nodeArray[(i + padding) * resolutionX + (j + padding)].B = i;
-			this->nodeArray[(i + padding) * resolutionX + (j + padding)].E = j;
-		}
-	}
 }
 
 // Returns an editable reference to the specified field node

--- a/PICADOR-Jr-Project/Source/FieldGrid.cpp
+++ b/PICADOR-Jr-Project/Source/FieldGrid.cpp
@@ -3,7 +3,15 @@
 FieldGrid::FieldGrid(size_t resolutionX_, size_t resolutionY_, double deltaX_, double deltaY_, const Vector3& origin_, size_t padding_):
 	Grid(resolutionX_, resolutionY_, deltaX_, deltaY_, origin_, padding_)
 {
-	this->nodeArray = std::vector<FieldData>((this->resolutionX + 2*this->padding) * (this->resolutionY+2*this->padding));
+	this->nodeArray = std::vector<FieldData>((this->resolutionX + 2*this->padding) * (this->resolutionY+2*this->padding), FieldData());
+	for (int i = 0; i < resolutionX; i++) 
+	{
+		for (int j = 0; j < resolutionY; j++)
+		{
+			this->nodeArray[(i + padding) * resolutionX + (j + padding)].B = i;
+			this->nodeArray[(i + padding) * resolutionX + (j + padding)].E = j;
+		}
+	}
 }
 
 // Returns an editable reference to the specified field node
@@ -22,18 +30,18 @@ const FieldData& FieldGrid::getNodeAt(GRID_INDEX i, GRID_INDEX j) const
 // Returns interpolated values of fields in the given point
 FieldData FieldGrid::getFieldsAt(const Vector3& location) const
 {
-	size_t i = this->getCell(location).first, j = this->getCell(location).first;
+	size_t i = this->getCell(location).first, j = this->getCell(location).second;
 	Vector3 cellOrigin(this->origin.x + i * this->deltaX, this->origin.y + j * this->deltaY, 0.0);
 	Vector3 delta(this->deltaX, this->deltaY, 1.0);
 
 	Vector3 newLocation = (location - cellOrigin) / delta;
 
 	FieldData interpolated;
-	interpolated.E = (this->getNodeAt(i, j)).E* (1 - newLocation.x) * (1 - newLocation.y) + (this->getNodeAt(i, j + 1)).E * (1 - newLocation.x) * newLocation.y + 
-		(this->getNodeAt(i + 1, j)).E * newLocation.x * (1 - newLocation.y) + (this->getNodeAt(i + 1, j+1)).E *  newLocation.x * newLocation.y;
+	interpolated.E = (this->getNodeAt(i, j)).E* (1.0 - newLocation.x) * (1.0 - newLocation.y) + (this->getNodeAt(i, j + 1)).E * (1.0 - newLocation.x) * newLocation.y + 
+		(this->getNodeAt(i + 1, j)).E * newLocation.x * (1.0 - newLocation.y) + (this->getNodeAt(i + 1, j+1)).E *  newLocation.x * newLocation.y;
 
-	interpolated.B = (this->getNodeAt(i, j)).B * (1 - newLocation.x) * (1 - newLocation.y) + (this->getNodeAt(i, j + 1)).B * (1 - newLocation.x) * newLocation.y +
-		(this->getNodeAt(i + 1, j)).B * newLocation.x * (1 - newLocation.y) + (this->getNodeAt(i + 1, j + 1)).B * newLocation.x * newLocation.y;
+	interpolated.B = (this->getNodeAt(i, j)).B * (1.0 - newLocation.x) * (1.0 - newLocation.y) + (this->getNodeAt(i, j + 1)).B * (1.0 - newLocation.x) * newLocation.y +
+		(this->getNodeAt(i + 1, j)).B * newLocation.x * (1.0 - newLocation.y) + (this->getNodeAt(i + 1, j + 1)).B * newLocation.x * newLocation.y;
 
 	interpolated.J = (this->getNodeAt(i, j)).J * (1 - newLocation.x) * (1 - newLocation.y) + (this->getNodeAt(i, j + 1)).J * (1 - newLocation.x) * newLocation.y +
 		(this->getNodeAt(i + 1, j)).J * newLocation.x * (1 - newLocation.y) + (this->getNodeAt(i + 1, j + 1)).J * newLocation.x * newLocation.y;

--- a/PICADOR-Jr-Project/Source/Vector3.cpp
+++ b/PICADOR-Jr-Project/Source/Vector3.cpp
@@ -68,6 +68,14 @@
         return result;
     }
 
+    bool Vector3::operator==(const Vector3& rhs) const {
+        return (this->x == rhs.x && this->y == rhs.y && this->z == rhs.z);
+    }
+
+    bool Vector3::operator!=(const Vector3& rhs) const {
+        return !((*this) == rhs);
+    }
+
 	// Scalar multiplication
 	double Vector3::dotProduct(const Vector3& rhs) const
     {

--- a/PICADOR-Jr-Project/test/test_grid.cpp
+++ b/PICADOR-Jr-Project/test/test_grid.cpp
@@ -23,7 +23,7 @@ TEST(FieldGrid, doesntThrowForCorrectLocation)
 	
 }
 
-TEST(FieldGrid, getCellReturnCorrectCellInComplexGrid)
+TEST(FieldGrid, getCellReturnsCorrectCellInComplexGrid)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
 
@@ -34,7 +34,7 @@ TEST(FieldGrid, getCellReturnCorrectCellInComplexGrid)
 
 }
 
-TEST(FieldGrid, getCellReturnCorrectCellForTheOrigin)
+TEST(FieldGrid, getCellReturnsCorrectCellForTheOrigin)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
 
@@ -45,7 +45,7 @@ TEST(FieldGrid, getCellReturnCorrectCellForTheOrigin)
 
 }
 
-TEST(FieldGrid, getCellReturnCorrectCellForTheResolution)
+TEST(FieldGrid, getCellReturnsCorrectCellForTheResolution)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
 
@@ -54,4 +54,58 @@ TEST(FieldGrid, getCellReturnCorrectCellForTheResolution)
 
 	EXPECT_EQ(ans, indices);
 
+}
+
+TEST(FieldGrid, getNodeAtThrowsForIncorrectIndices)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	ASSERT_ANY_THROW(field.getNodeAt(-1, -1));
+	ASSERT_ANY_THROW(field.getNodeAt(3, 3));
+}
+
+TEST(FieldGrid, getNodeAtDoesntThrowForCorrectIndices)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	ASSERT_NO_THROW(field.getNodeAt(1, 2));
+}
+
+TEST(FieldGrid, getNodeAtReturnsCorrectNode) 
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	FieldData ans;
+	ans.B = 1;
+	ans.E = 2;
+
+	EXPECT_EQ(ans.B, field.getNodeAt(1, 2).B);
+	EXPECT_EQ(ans.E, field.getNodeAt(1, 2).E);
+	EXPECT_EQ(ans.J, field.getNodeAt(1, 2).J);
+}
+
+TEST(FieldGrid, getFieldsAtReturnsCorrectField)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	FieldData ans;
+	ans.B = 1.5;
+	ans.E = 0.5;
+
+	EXPECT_EQ(ans.B, field.getFieldsAt(Vector3(2.5, 1.5)).B);
+	EXPECT_EQ(ans.E, field.getFieldsAt(Vector3(2.5, 1.5)).E);
+	EXPECT_EQ(ans.J, field.getFieldsAt(Vector3(2.5, 1.5)).J);
+}
+
+TEST(FieldGrid, anotherInterpolationTest)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	FieldData ans;
+	ans.B = 1.1;
+	ans.E = 0.5;
+
+	EXPECT_EQ(ans.B, field.getFieldsAt(Vector3(2.1, 1.5)).B);
+	EXPECT_EQ(ans.E, field.getFieldsAt(Vector3(2.1, 1.5)).E);
+	EXPECT_EQ(ans.J, field.getFieldsAt(Vector3(2.1, 1.5)).J);
 }

--- a/PICADOR-Jr-Project/test/test_grid.cpp
+++ b/PICADOR-Jr-Project/test/test_grid.cpp
@@ -1,0 +1,57 @@
+#include "FieldGrid.h"
+
+#include <gtest.h>
+
+TEST(FieldGrid, canCreatePrimitiveGrid)
+{
+  ASSERT_NO_THROW(FieldGrid(1, 1, 1.0, 1.0, Vector3::Zero, 1));
+}
+
+TEST(FieldGrid, throwsForInvalidLocation)
+{
+	FieldGrid field(2, 2, 1.0, 1.0, Vector3::Zero, 1);
+
+	ASSERT_ANY_THROW(field.getCell(Vector3(2.0, 2.0, 2.0)));
+	ASSERT_ANY_THROW(field.getCell(Vector3(-1.0, 0.5, 0.0)));
+}
+
+TEST(FieldGrid, doesntThrowForCorrectLocation)
+{
+	FieldGrid field(2, 2, 1.0, 1.0, Vector3::Zero, 1);
+
+	ASSERT_NO_THROW(field.getCell(Vector3(0.5, 0.5, 0.0)));
+	
+}
+
+TEST(FieldGrid, getCellReturnCorrectCellInComplexGrid)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	std::pair<GRID_INDEX, GRID_INDEX> ans = std::pair<GRID_INDEX, GRID_INDEX>(0, 1);
+	std::pair<GRID_INDEX, GRID_INDEX> indices = field.getCell(Vector3(1.5, 2.5, 0.0));
+
+	EXPECT_EQ(ans, indices);
+
+}
+
+TEST(FieldGrid, getCellReturnCorrectCellForTheOrigin)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	std::pair<GRID_INDEX, GRID_INDEX> ans = std::pair<GRID_INDEX, GRID_INDEX>(0, 0);
+	std::pair<GRID_INDEX, GRID_INDEX> indices = field.getCell(field.getOrigin());
+
+	EXPECT_EQ(ans, indices);
+
+}
+
+TEST(FieldGrid, getCellReturnCorrectCellForTheResolution)
+{
+	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	std::pair<GRID_INDEX, GRID_INDEX> ans = std::pair<GRID_INDEX, GRID_INDEX>(2, 2);
+	std::pair<GRID_INDEX, GRID_INDEX> indices = field.getCell(Vector3(field.getDeltaX()*field.getResolutionX(), field.getDeltaY() * field.getResolutionY()));
+
+	EXPECT_EQ(ans, indices);
+
+}

--- a/PICADOR-Jr-Project/test/test_grid.cpp
+++ b/PICADOR-Jr-Project/test/test_grid.cpp
@@ -75,6 +75,14 @@ TEST(FieldGrid, getNodeAtReturnsCorrectNode)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
 
+	for (int i = 0; i < field.getResolutionX(); i++) {
+		for (int j = 0; j < field.getResolutionY(); j++) {
+			field.getNodeAt(i, j).B = i;
+			field.getNodeAt(i, j).E = j;
+		}
+	}
+
+
 	FieldData ans;
 	ans.B = 1;
 	ans.E = 2;
@@ -88,6 +96,13 @@ TEST(FieldGrid, getFieldsAtReturnsCorrectField)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
 
+	for (int i = 0; i < field.getResolutionX(); i++) {
+		for (int j = 0; j < field.getResolutionY(); j++) {
+			field.getNodeAt(i, j).B = i;
+			field.getNodeAt(i, j).E = j;
+		}
+	}
+
 	FieldData ans;
 	ans.B = 1.5;
 	ans.E = 0.5;
@@ -100,6 +115,13 @@ TEST(FieldGrid, getFieldsAtReturnsCorrectField)
 TEST(FieldGrid, anotherInterpolationTest)
 {
 	FieldGrid field(3, 3, 1.0, 1.0, Vector3::One, 1);
+
+	for (int i = 0; i < field.getResolutionX(); i++) {
+		for (int j = 0; j < field.getResolutionY(); j++) {
+			field.getNodeAt(i, j).B = i;
+			field.getNodeAt(i, j).E = j;
+		}
+	}
 
 	FieldData ans;
 	ans.B = 1.1;


### PR DESCRIPTION
поменяла заполнение FieldGrid: теперь в узле с индексами (i,j) поле B представлено вектором (i, i, i), поле E вектором (j, j, j), поле J осталось нулевым вектором

было реализовано сравнение векторов (операторы ==/!=)

написаны тесты на интерполяцию, судя по всему она считается корректно